### PR TITLE
Moved Retrieving Token to API

### DIFF
--- a/frontend/src/components/MainApp/MainApp.tsx
+++ b/frontend/src/components/MainApp/MainApp.tsx
@@ -19,8 +19,8 @@ const MainApp = ({ children }: { children: ReactNode }): JSX.Element => {
     const [pageState, setPageState] = useState<PageState>(PageState.Loading);
     const [cookies, setCookie, removeCookie] = useCookies(['dfcuser']);
 
-    const loadUser = async (token: string | undefined = undefined) => {
-        const [data, error] = await Api.Get<UserAccount>('auth/getuser', { token: token || cookies.dfcuser });
+    const loadUser = async () => {
+        const [data, error] = await Api.Get<UserAccount>('auth/getuser');
 
         if (error || data === null) {
             setPageError(error || 'Unable to load site settings');
@@ -71,7 +71,7 @@ const MainApp = ({ children }: { children: ReactNode }): JSX.Element => {
 
     const loginUser = (token: string) => {
         setCookie('dfcuser', token, { path: '/' });
-        loadUser(token);
+        loadUser();
     };
 
     if (pageState === PageState.Loading) {

--- a/frontend/src/components/Pages/Roles/RoleForm.tsx
+++ b/frontend/src/components/Pages/Roles/RoleForm.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
     Form,
     Input,
@@ -6,7 +6,6 @@ import {
     Alert,
 } from 'antd';
 import { Api } from '@utils/api';
-import AppContext from '@contexts/AppContext';
 import { RoleType } from '@models/RoleType';
 import FormModal from '@components/FormModal';
 
@@ -33,8 +32,6 @@ const RoleForm = ({
     const [loadingMessage, setLoadingMessage] = useState<string>('');
     const [errorMessage, setErrorMessage] = useState<string>('');
 
-    const { token } = useContext(AppContext);
-
     const resetForm = () => {
         form.resetFields();
         setErrorMessage('');
@@ -43,7 +40,7 @@ const RoleForm = ({
     const getRoleType = async (id: string) => {
         setLoadingMessage('Loading...');
 
-        const [data, error] = await Api.Get<RoleType>('system/getrolebyid', { params: { id }, token });
+        const [data, error] = await Api.Get<RoleType>('system/getrolebyid', { params: { id } });
 
         if (error) {
             setErrorMessage(error);
@@ -68,7 +65,6 @@ const RoleForm = ({
         }
 
         const [, error] = await Api.Post('system/saverole', {
-            token,
             data: {
                 id,
                 name: values.name,

--- a/frontend/src/components/Pages/Roles/Roles.tsx
+++ b/frontend/src/components/Pages/Roles/Roles.tsx
@@ -20,12 +20,12 @@ const Roles = (): JSX.Element => {
     const [rolesLoadingMessage, setRolesLoadingMessage] = useState<string>('Loading...');
     const [roleToEditId, setRoleToEditId] = useState<string>('');
 
-    const { siteSettings, token } = useContext(AppContext);
+    const { siteSettings } = useContext(AppContext);
 
     const fetchRoles = async () => {
         setRolesLoadingMessage('Loading...');
 
-        const [data, error] = await Api.Get<RoleType[]>('system/getroles', { token });
+        const [data, error] = await Api.Get<RoleType[]>('system/getroles');
 
         if (error || data === null) {
             setRolesLoadingMessage('');

--- a/frontend/src/components/Pages/Roles/RolesTable.tsx
+++ b/frontend/src/components/Pages/Roles/RolesTable.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 import {
     Table,
     Button,
@@ -7,7 +7,6 @@ import {
 import { ColumnsType } from 'antd/lib/table';
 import ConfirmDialog from '@components/ConfirmDialog';
 import { Api } from '@utils/api';
-import AppContext from '@contexts/AppContext';
 import { RoleType } from '@models/RoleType';
 
 type RolesTableProps = {
@@ -25,10 +24,8 @@ const RolesTable = ({
 }: RolesTableProps): JSX.Element => {
     const [errorMessage, setErrorMessage] = useState<string>('');
 
-    const { token } = useContext(AppContext);
-
     const deleteRole = async (id: string) => {
-        const [, error] = await Api.Post('system/deleterole', { data: { id }, token });
+        const [, error] = await Api.Post('system/deleterole', { data: { id } });
 
         if (error) {
             setErrorMessage(error);

--- a/frontend/src/components/Pages/SiteSettings/SiteSettingsForm.tsx
+++ b/frontend/src/components/Pages/SiteSettings/SiteSettingsForm.tsx
@@ -29,14 +29,13 @@ const SiteSettingsForm = (): JSX.Element => {
 
     const [form] = Form.useForm<FormValues>();
 
-    const { siteSettings, token, updateSiteSettings } = useContext(AppContext);
+    const { siteSettings, updateSiteSettings } = useContext(AppContext);
 
     const submitForm = async ({ title, isPublic, allowPublicRegistration }: FormValues) => {
         setLoadingMessage('Saving...');
         setErrorMessage('');
 
         const [, error] = await Api.Post('system/savesitesettings', {
-            token,
             data: {
                 title,
                 isPublic,
@@ -70,7 +69,6 @@ const SiteSettingsForm = (): JSX.Element => {
         const [data, error] = await Api.Post<SiteSettings>(
             'system/refreshinvitationcode',
             {
-                token,
                 data: {},
             },
         );

--- a/frontend/src/components/Pages/Users/UsersGrid.tsx
+++ b/frontend/src/components/Pages/Users/UsersGrid.tsx
@@ -16,13 +16,10 @@ const UsersGrid = (): JSX.Element => {
     const [errorMessage, setErrorMessage] = useState<string>('');
     const [loadingMessage, setLoadingMessage] = useState<string>('Loading...');
 
-    const {
-        user,
-        token,
-    } = useContext(AppContext);
+    const { user } = useContext(AppContext);
 
     const fetchUsers = async () => {
-        const [data, error] = await Api.Get<UserAccount[]>('system/getusers', { params: { includeRoles: true }, token });
+        const [data, error] = await Api.Get<UserAccount[]>('system/getusers', { params: { includeRoles: true } });
 
         if (error || data === null) {
             setErrorMessage(error || 'An error has occurred');
@@ -37,7 +34,7 @@ const UsersGrid = (): JSX.Element => {
     const deleteUser = async (id: string) => {
         setLoadingMessage('Deleting User...');
 
-        const [, error] = await Api.Post('system/deleteuser', { data: { id }, token });
+        const [, error] = await Api.Post('system/deleteuser', { data: { id } });
 
         if (error) {
             setErrorMessage(error);
@@ -57,7 +54,6 @@ const UsersGrid = (): JSX.Element => {
                     userAccountId: userId,
                     roleName: 'Administrator',
                 },
-                token,
             },
         );
 
@@ -79,7 +75,6 @@ const UsersGrid = (): JSX.Element => {
                     userAccountId: userId,
                     roleName: 'Administrator',
                 },
-                token,
             },
         );
 

--- a/frontend/src/models/ApiArguments.ts
+++ b/frontend/src/models/ApiArguments.ts
@@ -3,7 +3,6 @@ export interface ApiArguments {
     data?: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     params?: any,
-    token?: string,
     contentType?: string,
     fileUpload?: boolean,
 }

--- a/frontend/src/utils/CookieUtils.ts
+++ b/frontend/src/utils/CookieUtils.ts
@@ -1,10 +1,26 @@
 class CookieUtils {
-    static GetCookie(name: string): boolean {
+    static GetValue(name: string): string | null {
+        const cookieName = `${name}=`;
+
+        const ca = document.cookie.split(';');
+
+        for (let i = 0; i < ca.length; i += 1) {
+            const c = ca[i].trim();
+
+            if ((c.indexOf(cookieName)) === 0) {
+                return c.substring(cookieName.length);
+            }
+        }
+
+        return null;
+    }
+
+    static Exists(name: string): boolean {
         return document.cookie.split(';').some((c) => c.trim().startsWith(`${name}=`));
     }
 
     static DeleteCookie(name: string, path = '/', domain = ''): void {
-        if (this.GetCookie(name)) {
+        if (this.Exists(name)) {
             document.cookie = `${name}=${
                 (path) ? `;path=${path}` : ''
             }${(domain) ? `;domain=${domain}` : ''

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -20,7 +20,7 @@ class Api {
 
         url = url.substring(0, url.length - 1);
 
-        return client(url, { token: config.token }).then(
+        return client(url).then(
             (data) => [data, null],
             (error) => [null, handleApiError(error)],
         );

--- a/frontend/src/utils/client.ts
+++ b/frontend/src/utils/client.ts
@@ -5,13 +5,14 @@ const apiUrl = process.env.REACT_APP_API_URL;
 
 async function client(endpoint: string, {
     data = null,
-    token = undefined,
     contentType = 'application/json',
     fileUpload = false,
     ...customConfig
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }: ApiArguments = {}) : Promise<any> {
     const headers: Record<string, string> = {};
+
+    const token = CookieUtils.GetValue('dfcuser');
 
     if (token) {
         headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
Tokens used to be handled in the components. To simplify matters until HTTP Only Cookies are implemented, the API will now handle retrieving the cookie.

Closes #66 