### PR TITLE
Removed Console.WriteLine

### DIFF
--- a/backend/src/DigitalFamilyCookbook/Handlers/Commands/Recipes/DeleteRecipeImage.cs
+++ b/backend/src/DigitalFamilyCookbook/Handlers/Commands/Recipes/DeleteRecipeImage.cs
@@ -15,8 +15,6 @@ public class DeleteRecipeImage
         {
             try
             {
-                Console.WriteLine($"IMAGE NAME: {command.ImageFilename}");
-
                 await Task.Run(() =>
                 {
                     _fileService.DeleteRecipeImage(command.ImageFilename);


### PR DESCRIPTION
I forgot to remove a `Console.WriteLine` from my work on the Add Recipe Form

closes #76 